### PR TITLE
Add a cleanup trap for the Xvfb process

### DIFF
--- a/hack/test-headless.sh
+++ b/hack/test-headless.sh
@@ -4,10 +4,19 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+function cleanup_xvfb() {
+	if [[ -n "${xvfb_process:-}" ]]; then
+		kill -SIGTERM "${xvfb_process}"
+	fi
+}
+
+trap cleanup_xvfb EXIT
+
 echo "[INFO] Starting virtual framebuffer for headless tests..."
 export DISPLAY=':10'
 export SCREEN='0'
 Xvfb "${DISPLAY}" -screen "${SCREEN}" 1024x768x24 -ac &
+xvfb_process="$!"
 
 # Debian versions of `xrandr` want `-display` whereas RPM
 # versions want `--display`, so we'll just use `-d` to


### PR DESCRIPTION
In order to allow for a user to run tests using the
headless script multiple times on their machine, it
is necessary to clean up the Xvfb process that holds
the $SCREEN.

Signed-off-by: Steve Kuznetsov skuznets@redhat.com
