### PR TITLE
[WIP] Begin work on showing better instance statuses

### DIFF
--- a/app/scripts/controllers/newOverview.js
+++ b/app/scripts/controllers/newOverview.js
@@ -94,6 +94,7 @@ function OverviewController($scope,
     routesByService: {},
     servicesByObjectUID: {},
     serviceInstances: {},
+    bindingsByInstanceRef: {},
     // Set to true below when metrics are available.
     showMetrics: false
   };
@@ -1072,7 +1073,7 @@ function OverviewController($scope,
   }, 300);
 
   // TODO: code duplicated from directives/bindService.js
-  // extract & share 
+  // extract & share
   var sortServiceInstances = function() {
     if(!state.serviceInstances && !state.serviceClasses) {
       return;
@@ -1263,6 +1264,13 @@ function OverviewController($scope,
         resource: 'bindings'
       }, context, function(bindings) {
         state.bindings = bindings.by('metadata.name');
+        state.bindingsByInstanceRef = _.reduce(state.bindings, function(result, next) {
+          if(!result[next.spec.instanceRef.name]) {
+            result[next.spec.instanceRef.name] = [];
+          }
+          result[next.spec.instanceRef.name].push(next);
+          return result;
+        }, {});
         refreshSecrets(context);
         updateFilter();
       }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));

--- a/app/scripts/directives/bindService.js
+++ b/app/scripts/directives/bindService.js
@@ -37,13 +37,13 @@ function BindService($filter,
     ctrl.gotoStep(ctrl.steps[0]);
   };
 
-  var statusCondition = $filter('statusCondition');
+  var statusConditionReady = $filter('statusConditionReady');
   ctrl.$onChanges = function(changes) {
     if (changes.serviceInstances && !ctrl.serviceToBind) {
       var newestReady;
       var newestNotReady;
       _.each(ctrl.serviceInstances, function(instance) {
-        var ready = _.get(statusCondition(instance, 'Ready'), 'status') === 'True';
+        var ready = statusConditionReady(instance);
         if (ready && (!newestReady || instance.metadata.creationTimestamp > newestReady.metadata.creationTimestamp)) {
           newestReady = instance;
         }

--- a/app/scripts/directives/overview/serviceInstanceRow.js
+++ b/app/scripts/directives/overview/serviceInstanceRow.js
@@ -11,7 +11,8 @@ angular.module('openshiftConsole').component('serviceInstanceRow', {
   controllerAs: 'row',
   bindings: {
     apiObject: '<',
-    state: '<'
+    state: '<',
+    bindings: '<'
   },
   templateUrl: 'views/overview/_service-instance-row.html'
 });
@@ -21,7 +22,8 @@ function ServiceInstanceRow($filter, DataService, rowMethods, $uibModal) {
   _.extend(row, rowMethods.ui);
 
   var getErrorDetails = $filter('getErrorDetails');
-
+  var statusConditionReady = $filter('statusConditionReady');
+  
   var getDisplayName = function() {
     var serviceClassName = row.apiObject.spec.serviceClassName;
     var instanceName = row.apiObject.metadata.name;
@@ -44,13 +46,15 @@ function ServiceInstanceRow($filter, DataService, rowMethods, $uibModal) {
     row.notifications = rowMethods.getNotifications(row.apiObject, row.state);
     row.displayName = getDisplayName();
     row.description = getDescription();
-    row.instanceBindings = getBindings();
   };
 
   row.getSecretForBinding = function(binding) {
     return binding && _.get(row, ['state', 'secrets', binding.spec.secretName]);
   };
 
+  row.showSecretLink = function(binding) {
+    return statusConditionReady(binding);
+  };
 
   row.deprovision = function() {
     var modalScope = {

--- a/app/scripts/directives/overview/serviceInstanceRow.js
+++ b/app/scripts/directives/overview/serviceInstanceRow.js
@@ -22,8 +22,9 @@ function ServiceInstanceRow($filter, DataService, rowMethods, $uibModal) {
   _.extend(row, rowMethods.ui);
 
   var getErrorDetails = $filter('getErrorDetails');
+  var statusCondition = $filter('statusCondition');
   var statusConditionReady = $filter('statusConditionReady');
-  
+
   var getDisplayName = function() {
     var serviceClassName = row.apiObject.spec.serviceClassName;
     var instanceName = row.apiObject.metadata.name;
@@ -46,6 +47,9 @@ function ServiceInstanceRow($filter, DataService, rowMethods, $uibModal) {
     row.notifications = rowMethods.getNotifications(row.apiObject, row.state);
     row.displayName = getDisplayName();
     row.description = getDescription();
+    row.status = statusCondition(row.apiObject).status;
+    row.statusReason = statusCondition(row.apiObject).reason;
+    row.isReady = statusConditionReady(row.apiObject);
   };
 
   row.getSecretForBinding = function(binding) {

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1084,13 +1084,32 @@ angular.module('openshiftConsole')
       return lastFinishTime;
     };
   })
+  // gets the first status condition.
   .filter('statusCondition', function() {
+    return function(apiObject) {
+      if (!apiObject) {
+        return null;
+      }
+
+      return _.first(_.get(apiObject, 'status.conditions'));
+    };
+  })
+  // gets the status condition that matches provided type
+  // statusConditionIs(object, 'Ready')
+  .filter('statusConditionIs', function() {
     return function(apiObject, type) {
       if (!apiObject) {
         return null;
       }
 
       return _.find(_.get(apiObject, 'status.conditions'), {type: type});
+    };
+  })
+  // returns true/false based on the presence of a Ready status conditions
+  // statusConditionReady(obj)
+  .filter('statusConditionReady', function(statusConditionFilter) {
+    return function(apiObject) {
+      return _.get(statusConditionFilter(apiObject, 'Ready'), 'status') === 'True';
     };
   })
   .filter('routeIngressCondition', function() {

--- a/app/views/new-overview.html
+++ b/app/views/new-overview.html
@@ -365,6 +365,7 @@
                   <service-instance-row
                     ng-repeat="serviceInstance in overview.state.orderedServiceInstances"
                     api-object="serviceInstance"
+                    bindings="overview.state.bindingsByInstanceRef[serviceInstance.metadata.name]"
                     state="overview.state"></service-instance-row>
                 </div>
               </div>

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -14,13 +14,18 @@
           </div>
         </h3>
         <div class="status-icons">
+          <!--
+            TODO: this should show an info status icon if the apiObject is not yet ready.
+          -->
           <notification-icon ng-if="!row.expanded" alerts="row.notifications"></notification-icon>
+          <span ng-if="!row.isReady">
+            <status-icon status="row.status"></status-icon> {{row.statusReason | sentenceCase}}
+          </span>
         </div>
       </div>
     </div>
 
-    <div
-      class="list-pf-content hidden-xs hidden-sm">
+    <div class="list-pf-content hidden-xs hidden-sm">
       <div class="list-pf-content-right">
         <div>
           <strong ng-if="!row.instanceBindings.length">No Bindings</strong>

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -93,19 +93,24 @@
       <div class="section-title">
         Bindings
       </div>
-      <span ng-if="!row.instanceBindings.length">There are no bindings.</span>
+      <span ng-if="!row.bindings.length">There are no bindings.</span>
       <div
-        ng-if="row.instanceBindings.length"
+        ng-if="row.bindings.length"
         class="row"
-        ng-repeat="binding in row.instanceBindings">
-        <div class="col-sm-4">
+        ng-repeat="binding in row.bindings">
+        <div class="col-sm-5">
           <span>{{binding.metadata.name}}</span>
         </div>
-        <div class="col-sm-8">
+        <div class="col-sm-7">
           <!-- TODO: follow-on PR
           <a ng-href="{{binding | navigateResourceURL}}">View configuration details</a>
           -->
-          <a href="{{row.getSecretForBinding(binding) | navigateResourceURL}}">
+          <span ng-if="!row.showSecretLink(binding)">
+            <status-icon status="'Pending'"></status-icon> Pending
+          </span>
+          <a
+            ng-if="row.showSecretLink(binding)"
+            href="{{row.getSecretForBinding(binding) | navigateResourceURL}}">
             View secret
           </a>
         </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11496,7 +11496,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Provisioned Services\n" +
     "</h2>\n" +
     "<div class=\"list-pf\">\n" +
-    "<service-instance-row ng-repeat=\"serviceInstance in overview.state.orderedServiceInstances\" api-object=\"serviceInstance\" state=\"overview.state\"></service-instance-row>\n" +
+    "<service-instance-row ng-repeat=\"serviceInstance in overview.state.orderedServiceInstances\" api-object=\"serviceInstance\" bindings=\"overview.state.bindingsByInstanceRef[serviceInstance.metadata.name]\" state=\"overview.state\"></service-instance-row>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -12680,14 +12680,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"section-title\">\n" +
     "Bindings\n" +
     "</div>\n" +
-    "<span ng-if=\"!row.instanceBindings.length\">There are no bindings.</span>\n" +
-    "<div ng-if=\"row.instanceBindings.length\" class=\"row\" ng-repeat=\"binding in row.instanceBindings\">\n" +
-    "<div class=\"col-sm-4\">\n" +
+    "<span ng-if=\"!row.bindings.length\">There are no bindings.</span>\n" +
+    "<div ng-if=\"row.bindings.length\" class=\"row\" ng-repeat=\"binding in row.bindings\">\n" +
+    "<div class=\"col-sm-5\">\n" +
     "<span>{{binding.metadata.name}}</span>\n" +
     "</div>\n" +
-    "<div class=\"col-sm-8\">\n" +
+    "<div class=\"col-sm-7\">\n" +
     "\n" +
-    "<a href=\"{{row.getSecretForBinding(binding) | navigateResourceURL}}\">\n" +
+    "<span ng-if=\"!row.showSecretLink(binding)\">\n" +
+    "<status-icon status=\"'Pending'\"></status-icon> Pending\n" +
+    "</span>\n" +
+    "<a ng-if=\"row.showSecretLink(binding)\" href=\"{{row.getSecretForBinding(binding) | navigateResourceURL}}\">\n" +
     "View secret\n" +
     "</a>\n" +
     "</div>\n" +


### PR DESCRIPTION
Working on showing better instance statuses.  Example here: Deprovision call failed:

![screen shot 2017-04-11 at 4 23 32 pm](https://cloud.githubusercontent.com/assets/280512/24929227/3fd825b0-1ed3-11e7-8c97-ba0e7fb885e9.png)

I haven't addressed the ragged edges/wobble yet, though I have been looking at the markup.  We're doing `flex` ad-hoc atm, rather than a framework approach like bootstrap, I'm a little concerned we may regret that down the road.  Open to thoughts, otherwise I'll prob redo the row `flex` here differently than is done for the above rows.

@spadgett @jwforres

(I did deliberately PR against my own branch to reduce noise)